### PR TITLE
fix: stop camera feed when QR page is left

### DIFF
--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -21,6 +21,10 @@ const QRScanner = ({ setId }: QRScannerProps) => {
 			},
 		);
 		void qrScanner.start();
+
+		return () => {
+			qrScanner.stop();
+		};
 	});
 	return <video ref={video} className="aspect-square rounded-3xl object-cover" width="300" height="300" />;
 };


### PR DESCRIPTION
There was a slight bug on the QR scan page which was causing the camera feed to not be closed when the page was switched. This was fixed by modifying the `QRScanner` component's `useEffect()` hook to close the camera feed when the component is unloaded. 