### PR TITLE
updating navbar to show walkin entry for organizers

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -122,14 +122,24 @@ const Links = () => {
 				Resources
 			</Link>
 			{sessionData?.user && (
-				<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
-					<Link
-						href="/hackers"
-						className="mx-4 flex items-center font-coolvetica text-2xl text-dark hover:text-light"
-					>
-						Hackers
-					</Link>
-				</OnlyRole>
+				<>
+					<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
+						<Link
+							href="/hackers"
+							className="mx-4 flex items-center font-coolvetica text-2xl text-dark hover:text-light"
+						>
+							Hackers
+						</Link>
+					</OnlyRole>
+					<OnlyRole roles={[Role.ORGANIZER]}>
+						<Link
+							href="/walk-in"
+							className="mx-4 flex items-center font-coolvetica text-2xl text-dark hover:text-light"
+						>
+							Walk-In
+						</Link>
+					</OnlyRole>
+				</>
 			)}
 		</>
 	);


### PR DESCRIPTION
Had to wrap the `OnlyRole` tags in an empty JSX tag so the compiler wouldn't make a fuss. 

![image](https://github.com/HacktheHill/track-the-hack/assets/26064522/56fdd91e-c14b-4794-9006-656fb68224c8)

Issue: Walk-in Form in Nav Bar #72 