### PR TITLE
refactor: reverted `OnlyRole` component to use `filter`

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -82,7 +82,7 @@ const BottomMenu = () => {
 				<Image priority src="/assets/resources.svg" height={32} width={32} alt="Resources" />
 			</Link>
 			{sessionData?.user && (
-				<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
+				<OnlyRole filter={role => role === Role.ORGANIZER || role === Role.SPONSOR}>
 					<Link href="/hackers">
 						<Image priority src="/assets/list.svg" height={32} width={32} alt="Hackers" />
 					</Link>
@@ -123,7 +123,7 @@ const Links = () => {
 			</Link>
 			{sessionData?.user && (
 				<>
-					<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
+					<OnlyRole filter={role => role === Role.ORGANIZER || role === Role.SPONSOR}>
 						<Link
 							href="/hackers"
 							className="mx-4 flex items-center font-coolvetica text-2xl text-dark hover:text-light"
@@ -131,7 +131,7 @@ const Links = () => {
 							Hackers
 						</Link>
 					</OnlyRole>
-					<OnlyRole roles={[Role.ORGANIZER]}>
+					<OnlyRole filter={role => role === Role.ORGANIZER}>
 						<Link
 							href="/walk-in"
 							className="mx-4 flex items-center font-coolvetica text-2xl text-dark hover:text-light"

--- a/src/components/OnlyRole.tsx
+++ b/src/components/OnlyRole.tsx
@@ -6,11 +6,11 @@ import type { Roles } from "../utils/common";
 import Error from "./Error";
 
 type OnlyRoleProps = {
-	roles: Roles[];
+	filter: (role: Roles) => boolean;
 	children: React.ReactNode;
 };
 
-const OnlyRole = ({ roles, children }: OnlyRoleProps) => {
+const OnlyRole = ({ filter, children }: OnlyRoleProps) => {
 	const { data: sessionData } = useSession();
 	const id = sessionData?.user?.id ?? "";
 
@@ -24,7 +24,7 @@ const OnlyRole = ({ roles, children }: OnlyRoleProps) => {
 		return <Error message={query.error.message} />;
 	}
 
-	if (query.data && roles.includes(query.data)) {
+	if (query.data && filter(query.data)) {
 		return <>{children}</>;
 	}
 

--- a/src/pages/hackers/hacker.tsx
+++ b/src/pages/hackers/hacker.tsx
@@ -31,10 +31,10 @@ const Hacker: NextPage = () => {
 	if (hackerQuery.isLoading || hackerQuery.data == null) {
 		return (
 			<App className="h-full bg-gradient-to-b from-background2 to-background1 px-16 py-12">
-				<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
+				<OnlyRole filter={role => role === Role.ORGANIZER || role === Role.SPONSOR}>
 					<Loading />
 				</OnlyRole>
-				<OnlyRole roles={[Role.HACKER]}>
+				<OnlyRole filter={role => role === Role.HACKER}>
 					<div className="flex flex-col items-center justify-center gap-4">
 						<Error message="You are not allowed to view this page" />
 					</div>
@@ -81,10 +81,10 @@ const Hacker: NextPage = () => {
 			title={`${hackerQuery.data.firstName} ${hackerQuery.data.lastName}`}
 		>
 			<div className="mx-auto flex max-w-2xl flex-col gap-4">
-				<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
+				<OnlyRole filter={role => role === Role.ORGANIZER || role === Role.SPONSOR}>
 					<HackerView hackerData={hackerQuery.data} presenceData={presenceQuery.data} />
 				</OnlyRole>
-				<OnlyRole roles={[Role.HACKER]}>{t("not-authorized-to-view-this-page")}</OnlyRole>
+				<OnlyRole filter={role => role === Role.HACKER}>{t("not-authorized-to-view-this-page")}</OnlyRole>
 			</div>
 		</App>
 	);
@@ -129,7 +129,7 @@ const HackerView = ({ hackerData, presenceData: { id: _, hackerInfoId, ...presen
 				{hackerData.university && `at ${hackerData.university}`}{" "}
 				{hackerData.graduationYear && `(${hackerData.graduationYear})`}
 			</p>
-			<OnlyRole roles={[Role.ORGANIZER]}>
+			<OnlyRole filter={role => role === Role.ORGANIZER}>
 				<div className="grid grid-flow-row grid-cols-2 gap-4 rounded-lg bg-background2 p-4">
 					{Object.entries(presenceState).map(([key, value]) => (
 						<p key={key}>
@@ -199,7 +199,7 @@ const HackerView = ({ hackerData, presenceData: { id: _, hackerInfoId, ...presen
 						),
 				)}
 			</p>
-			<OnlyRole roles={[Role.ORGANIZER]}>
+			<OnlyRole filter={role => role === Role.ORGANIZER}>
 				<>
 					<h2 className="self-center font-[Coolvetica] text-2xl font-normal text-dark">Debug Information</h2>
 					<p className={paragraphClass}>

--- a/src/pages/hackers/index.tsx
+++ b/src/pages/hackers/index.tsx
@@ -53,10 +53,10 @@ const Hackers: NextPage = () => {
 	if (query.isLoading || query.data == null) {
 		return (
 			<App className="h-full bg-gradient-to-b from-background2 to-background1 px-16 py-12">
-				<OnlyRole roles={[Role.ORGANIZER, Role.SPONSOR]}>
+				<OnlyRole filter={role => role === Role.ORGANIZER || role === Role.SPONSOR}>
 					<Loading />
 				</OnlyRole>
-				<OnlyRole roles={[Role.HACKER]}>
+				<OnlyRole filter={role => role === Role.HACKER}>
 					<div className="flex flex-col items-center justify-center gap-4">
 						<Error message={t("not-authorized-to-view-this-page")} />
 					</div>

--- a/src/pages/qr/index.tsx
+++ b/src/pages/qr/index.tsx
@@ -44,11 +44,11 @@ const QR = () => {
 		>
 			<Weather count={30} type="snowflake" />
 			<div className="flex flex-col items-center gap-6">
-				<OnlyRole roles={[Role.ORGANIZER]}>
+				<OnlyRole filter={role => role === Role.ORGANIZER}>
 					<QRScanner setId={setId} />
 					{!error && <p className="z-10 max-w-xl text-center text-lg font-bold text-dark">{t("scan-qr")}</p>}
 				</OnlyRole>
-				<OnlyRole roles={[Role.HACKER]}>
+				<OnlyRole filter={role => role === Role.HACKER}>
 					<QRCode setError={setError} />
 					{!error && <p className="z-10 max-w-xl text-center text-lg font-bold text-dark">{t("use-qr")}</p>}
 				</OnlyRole>

--- a/src/pages/walk-in/index.tsx
+++ b/src/pages/walk-in/index.tsx
@@ -216,7 +216,7 @@ const WalkIn: NextPage = () => {
 
 	return (
 		<App className="overflow-y-auto bg-gradient3 p-8 sm:p-12" title={t("title")}>
-			<OnlyRole roles={[Role.ORGANIZER]}>
+			<OnlyRole filter={role => role === Role.ORGANIZER}>
 				{success ? (
 					<div className="flex flex-col items-center gap-8">
 						<h3 className="font-rubik text-4xl font-bold text-dark">{t("title")}</h3>
@@ -276,7 +276,7 @@ const WalkIn: NextPage = () => {
 					</form>
 				)}
 			</OnlyRole>
-			<OnlyRole roles={[Role.HACKER]}>
+			<OnlyRole filter={role => role === Role.HACKER}>
 				<div className="flex flex-col items-center justify-center gap-4">
 					<Error message={t("not-authorized-to-view-this-page")} />
 				</div>


### PR DESCRIPTION
I can't remember whether we agreed on a style for `OnlyRole`, but I'd say this is more flexible. Moreover, it could be said that the style is consistent with `src/utils/helpers.ts`.