### PR TITLE
removed useEffect redirect for hackers page

### DIFF
--- a/src/pages/hackers/index.tsx
+++ b/src/pages/hackers/index.tsx
@@ -1,5 +1,5 @@
 import { Role, type HackerInfo } from "@prisma/client";
-import type { GetStaticProps, NextPage } from "next";
+import type { NextPage } from "next";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -13,12 +13,12 @@ import App from "../../components/App";
 import Error from "../../components/Error";
 import Loading from "../../components/Loading";
 import OnlyRole from "../../components/OnlyRole";
+import type { GetServerSideProps} from "next";
+import { authOptions } from "../api/auth/[...nextauth]";
+import { getServerSession } from "next-auth/next";
+import { PrismaClient } from "@prisma/client";
+import { hackersRedirect } from "../../utils/redirects";
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => {
-	return {
-		props: await serverSideTranslations(locale ?? "en", ["common", "hackers"]),
-	};
-};
 
 const Hackers: NextPage = () => {
 	const { t } = useTranslation("hackers");
@@ -43,12 +43,6 @@ const Hackers: NextPage = () => {
 			window.removeEventListener("resize", debouncedResizeHandler);
 		};
 	}, [updateColumns]);
-
-	useEffect(() => {
-		if (sessionData?.user == null) {
-			void router.push("/");
-		}
-	}, [router, sessionData?.user]);
 
 	if (query.isLoading || query.data == null) {
 		return (
@@ -174,5 +168,15 @@ const Search = ({ setSearch }: SearchProps) => {
 		</div>
 	);
 };
+
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res, locale }) => {
+	const props = await hackersRedirect(req, res, locale);
+
+	return {
+	  ...props,
+	};
+  };
+
 
 export default Hackers;

--- a/src/pages/walk-in/index.tsx
+++ b/src/pages/walk-in/index.tsx
@@ -41,8 +41,10 @@ const WalkIn: NextPage = () => {
 	}, [mutation.error, t]);
 
 	useEffect(() => {
+		console.log("INSIDE WALK-IN REDIRECT");
 		const timeout = setTimeout(() => {
 			if (sessionData?.user == null) {
+				//console.log("performing walk in redirect")
 				void router.push("/");
 			}
 		}, 1000);

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -1,0 +1,64 @@
+
+import { Role, type HackerInfo } from "@prisma/client";
+import type { NextPage } from "next";
+import { useSession } from "next-auth/react";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+import { authOptions } from "../pages/api/auth/[...nextauth]";
+import { getServerSession } from "next-auth/next";
+import { PrismaClient } from "@prisma/client";
+import { contextProps } from "@trpc/react-query/shared";
+import { procedureTypes } from "@trpc/server";
+import { renderToString } from 'react-dom/server';
+import type { GetServerSideProps} from "next";
+
+
+
+type ServerSideProps = {
+	redirect?: { destination: any; permanent: boolean } | null;
+	props: { [key: string]: any };
+};
+
+
+export async function hackersRedirect(req: any, res: any, locale: any): Promise<ServerSideProps> {
+
+    const prisma = new PrismaClient();
+    const session = await getServerSession(req, res, authOptions);
+  
+    const user =
+      session &&
+      (await prisma.user.findUnique({
+        where: {
+          id: session?.user?.id,
+        },
+      }));
+  
+    if (!user) {
+        return {
+            redirect: {
+              destination: "/api/auth/signin",
+              permanent: false,
+            },
+            props: {},
+          };
+    }
+  
+    if (user.role !== "ORGANIZER") {
+      return {
+        redirect: {
+          destination: "/",
+          permanent: false,
+        },
+        props: {},
+      };
+    }
+  
+    return {
+      props: await serverSideTranslations(locale ?? "en", ["common", "hackers"]),
+    };
+  }
+
+


### PR DESCRIPTION
made a helper function in the utils folder called "redirects" to use for server side redirects instead of useEffect for viewing hackers. Still have to do this for walk-ins. 