### PR TITLE
feat: dispay user avatar if any

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -161,6 +161,11 @@ const Navbar = ({ integrated }: NavbarProps) => {
 			>
 				{sessionData ? t("sign-out") : t("sign-in")}
 			</button>
+
+			{sessionData?.user?.image && (
+				// eslint-disable-next-line @next/next/no-img-element
+				<img className="rounded-full" src={sessionData.user.image} width={40} height={40} alt="User avatar" />
+			)}
 		</nav>
 	);
 };


### PR DESCRIPTION
- Display user avatar if defined in session.
- Doesnt use `next/image` because that would require whitelisting domains where we expect to fetch images from. `<img>`  is a simple solution and is fetched client side.