### PR TITLE
fix: organizer view to include Team name and members + HackerView Team members

### DIFF
--- a/public/locales/en/hacker.json
+++ b/public/locales/en/hacker.json
@@ -120,5 +120,6 @@
 	"save": "Save",
 	"invalid-form": "Please fill out all required fields.",
 	"success": "Saved changes successfully.",
-	"return-to-form": "Return to form"
+	"return-to-form": "Return to form",
+	"team": "Team"
 }

--- a/public/locales/fr/hacker.json
+++ b/public/locales/fr/hacker.json
@@ -110,5 +110,6 @@
 	"save": "Sauvegarder",
 	"invalid-form": "Veuillez remplir tous les champs obligatoires.",
 	"success": "Modifications enregistrées avec succès.",
-	"return-to-form": "Retour au formulaire"
+	"return-to-form": "Retour au formulaire",
+	"team": "Équipe"
 }


### PR DESCRIPTION
- Fix wrong condition in `resetFormFields` which made the fields empty for organizers
- Allows hackers to view team name and members from scanning
- Adds view to organizers to also see team names and members