### PR TITLE
Add HMAC bot verification and Azure deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.next
+node_modules
+.env*
+npm-debug.log*
+logs

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,53 @@
+name: Build and deploy Track the Hack
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    if: vars.AZURE_MIGRATION_ACTIVE == 'true'
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Create build environment file
+        run: node ./.github/workflows/create-env.mjs "$SECRETS" "$VARS"
+        env:
+          SECRETS: ${{ toJson(secrets) }}
+          VARS: ${{ toJson(vars) }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - uses: azure/docker-login@v2
+        with:
+          login-server: ${{ vars.AZURE_ACR_LOGIN_SERVER }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          secret-files: |
+            env=.env
+          tags: |
+            ${{ vars.AZURE_ACR_LOGIN_SERVER }}/track-the-hack:${{ github.sha }}
+            ${{ vars.AZURE_ACR_LOGIN_SERVER }}/track-the-hack:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az containerapp update \
+              --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+              --name "track-the-hack" \
+              --image "${{ vars.AZURE_ACR_LOGIN_SERVER }}/track-the-hack:${{ github.sha }}"

--- a/.github/workflows/create-env.mjs
+++ b/.github/workflows/create-env.mjs
@@ -6,9 +6,6 @@ console.info("Creating .env file...");
 const secrets = JSON.parse(process.argv[2]);
 const vars = JSON.parse(process.argv[3]);
 
-console.info("Secrets:", secrets);
-console.info("Vars:", vars);
-
 const env = { ...secrets, ...vars };
 
 const envFile = Object.keys(env)

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     build-and-deploy:
+        if: vars.AZURE_MIGRATION_ACTIVE != 'true'
         runs-on: self-hosted
         environment: Production
         steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.7
+FROM node:20-bookworm-slim AS build
+WORKDIR /app
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates openssl \
+	&& rm -rf /var/lib/apt/lists/*
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm ci
+COPY . .
+ENV NODE_ENV=production
+ENV SKIP_ENV_VALIDATION=1
+RUN --mount=type=secret,id=env \
+	set -a && . /run/secrets/env && set +a && npm run build
+RUN npm prune --omit=dev && npm cache clean --force
+
+FROM node:20-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates openssl \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& groupadd --system --gid 1001 app \
+	&& useradd --system --uid 1001 --gid app app
+COPY --from=build --chown=app:app /app/package*.json ./
+COPY --from=build --chown=app:app /app/node_modules ./node_modules
+COPY --from=build --chown=app:app /app/.next ./.next
+COPY --from=build --chown=app:app /app/public ./public
+COPY --from=build --chown=app:app /app/next.config.js ./
+COPY --from=build --chown=app:app /app/next-i18next.config.js ./
+COPY --from=build --chown=app:app /app/prisma ./prisma
+COPY --from=build --chown=app:app /app/src/env ./src/env
+USER app
+EXPOSE 3000
+STOPSIGNAL SIGTERM
+CMD ["sh", "-c", "npx prisma migrate deploy && npm run start"]

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -32,7 +32,7 @@ export const serverSchema = z.object({
 	SPONSORSHIP_GOOGLE_REFRESH_TOKEN: z.string(),
 	S3_URL: z.string().url(),
 	S3_AUTH_KEY: z.string(),
-	DISCORD_BOT_SECRET_KEY: z.string(),
+	INTERNAL_API_SECRET: z.string().min(32),
 	DISCORD_BOT_URL: z.string().url(),
 	QR_SECRET_KEY: z.string(),
 	WALK_IN_SECRET_KEY: z.string(),
@@ -64,7 +64,9 @@ export const serverEnv = {
 	SPONSORSHIP_GOOGLE_REFRESH_TOKEN: process.env.SPONSORSHIP_GOOGLE_REFRESH_TOKEN,
 	S3_URL: process.env.S3_URL,
 	S3_AUTH_KEY: process.env.S3_AUTH_KEY,
-	DISCORD_BOT_SECRET_KEY: process.env.DISCORD_BOT_SECRET_KEY,
+	// The fallback keeps existing build environments working during the rollout;
+	// requests are always sent with HMAC and the legacy value can be removed after cutover.
+	INTERNAL_API_SECRET: process.env.INTERNAL_API_SECRET ?? process.env.DISCORD_BOT_SECRET_KEY,
 	DISCORD_BOT_URL: process.env.DISCORD_BOT_URL,
 	QR_SECRET_KEY: process.env.QR_SECRET_KEY,
 	WALK_IN_SECRET_KEY: process.env.WALK_IN_SECRET_KEY,

--- a/src/server/api/routers/users.ts
+++ b/src/server/api/routers/users.ts
@@ -1,6 +1,7 @@
 import { RoleName } from "@prisma/client";
 import argon2 from "argon2";
 import { z } from "zod";
+import { createHmac } from "node:crypto";
 import { env } from "../../../env/server.mjs";
 import { hasRoles } from "../../../utils/helpers";
 import { log } from "../../lib/log";
@@ -198,15 +199,19 @@ export const userRouter = createTRPCRouter({
 				throw new Error("You have not yet been accepted as a hacker");
 			}
 
+			const body = JSON.stringify({ discordId: input.discordId });
+			const timestamp = Math.floor(Date.now() / 1000).toString();
+			const signature = createHmac("sha256", env.INTERNAL_API_SECRET)
+				.update(`${timestamp}.${body}`)
+				.digest("hex");
 			const response = await fetch(`${env.DISCORD_BOT_URL}/verify`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
+					"x-track-the-hack-timestamp": timestamp,
+					"x-track-the-hack-signature": signature,
 				},
-				body: JSON.stringify({
-					discordId: input.discordId,
-					secretKey: env.DISCORD_BOT_SECRET_KEY,
-				}),
+				body,
 			});
 
 			if (!response.ok) {


### PR DESCRIPTION
## What changed

- signs Track the Hack verification requests with timestamped HMAC headers
- adds a production multi-stage container image with verified MySQL TLS and startup migrations
- adds Azure Container Apps deployment through GitHub OIDC
- retains the VM workflow as a rollback path until the migration flag is enabled
- stops the environment helper from printing secret values

## Why

The web app now communicates with the private bot endpoint without sending a reusable secret in the request body and can be deployed independently of the legacy VM.

