### PR TITLE
fix(deps): remove obsolete next-pwa type package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
 			"devDependencies": {
 				"@faker-js/faker": "^8.3.1",
 				"@types/csvtojson": "^2.0.0",
-				"@types/next-pwa": "^5.6.9",
 				"@types/node": "^24.13.3",
 				"@types/nodemailer": "^6.4.15",
 				"@types/qrcode": "^1.5.5",
@@ -3400,23 +3399,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.9.tgz",
-			"integrity": "sha512-BLiPKJomaPrTAb7ykjA0LPcuuNMLDVK177Z1xe0nAem33+9FIayU4k/OWrtSn9SAJW/U60+1hoey5z+KCHdRLQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/@next/swc-win32-x64-msvc": {
 			"version": "15.5.20",
 			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
@@ -4113,256 +4095,6 @@
 			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
 			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"license": "MIT"
-		},
-		"node_modules/@types/next-pwa": {
-			"version": "5.6.9",
-			"resolved": "https://registry.npmjs.org/@types/next-pwa/-/next-pwa-5.6.9.tgz",
-			"integrity": "sha512-KcymH+MtFYB5KVKIOH1DMqd0wUb8VLCxzHtsaRQQ7S8sGOaTH24Lo2vGZf6/0Ok9e+xWCKhqsSt6cgDJTk91Iw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"next": "^12.2.5 || ^13.0.0",
-				"workbox-build": "^6.5.4"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/env": {
-			"version": "13.5.11",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
-			"integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-darwin-arm64": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.9.tgz",
-			"integrity": "sha512-pVyd8/1y1l5atQRvOaLOvfbmRwefxLhqQOzYo/M7FQ5eaRwA1+wuCn7t39VwEgDd7Aw1+AIWwd+MURXUeXhwDw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-darwin-x64": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.9.tgz",
-			"integrity": "sha512-DwdeJqP7v8wmoyTWPbPVodTwCybBZa02xjSJ6YQFIFZFZ7dFgrieKW4Eo0GoIcOJq5+JxkQyejmI+8zwDp3pwA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.9.tgz",
-			"integrity": "sha512-wdQsKsIsGSNdFojvjW3Ozrh8Q00+GqL3wTaMjDkQxVtRbAqfFBtrLPO0IuWChVUP2UeuQcHpVeUvu0YgOP00+g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-linux-arm64-musl": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.9.tgz",
-			"integrity": "sha512-6VpS+bodQqzOeCwGxoimlRoosiWlSc0C224I7SQWJZoyJuT1ChNCo+45QQH+/GtbR/s7nhaUqmiHdzZC9TXnXA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-linux-x64-gnu": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.9.tgz",
-			"integrity": "sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-linux-x64-musl": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.9.tgz",
-			"integrity": "sha512-/dnscWqfO3+U8asd+Fc6dwL2l9AZDl7eKtPNKW8mKLh4Y4wOpjJiamhe8Dx+D+Oq0GYVjuW0WwjIxYWVozt2bA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.9.tgz",
-			"integrity": "sha512-T/iPnyurOK5a4HRUcxAlss8uzoEf5h9tkd+W2dSWAfzxv8WLKlUgbfk+DH43JY3Gc2xK5URLuXrxDZ2mGfk/jw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@next/swc-win32-x64-msvc": {
-			"version": "13.5.9",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.9.tgz",
-			"integrity": "sha512-/72/dZfjXXNY/u+n8gqZDjI6rxKMpYsgBBYNZKWOQw0BpBF7WCnPflRy3ZtvQ2+IYI3ZH2bPyj7K+6a6wNk90Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/@swc/helpers": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/next": {
-			"version": "13.5.11",
-			"resolved": "https://registry.npmjs.org/next/-/next-13.5.11.tgz",
-			"integrity": "sha512-WUPJ6WbAX9tdC86kGTu92qkrRdgRqVrY++nwM+shmWQwmyxt4zhZfR59moXSI4N8GDYCBY3lIAqhzjDd4rTC8Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@next/env": "13.5.11",
-				"@swc/helpers": "0.5.2",
-				"busboy": "1.6.0",
-				"caniuse-lite": "^1.0.30001406",
-				"postcss": "8.4.31",
-				"styled-jsx": "5.1.1",
-				"watchpack": "2.4.0"
-			},
-			"bin": {
-				"next": "dist/bin/next"
-			},
-			"engines": {
-				"node": ">=16.14.0"
-			},
-			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "13.5.9",
-				"@next/swc-darwin-x64": "13.5.9",
-				"@next/swc-linux-arm64-gnu": "13.5.9",
-				"@next/swc-linux-arm64-musl": "13.5.9",
-				"@next/swc-linux-x64-gnu": "13.5.9",
-				"@next/swc-linux-x64-musl": "13.5.9",
-				"@next/swc-win32-arm64-msvc": "13.5.9",
-				"@next/swc-win32-ia32-msvc": "13.5.9",
-				"@next/swc-win32-x64-msvc": "13.5.9"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.1.0",
-				"react": "^18.2.0",
-				"react-dom": "^18.2.0",
-				"sass": "^1.3.0"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@types/next-pwa/node_modules/styled-jsx": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-			"integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"client-only": "0.0.1"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"peerDependencies": {
-				"react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"babel-plugin-macros": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@types/node": {
 			"version": "24.13.3",
@@ -5731,18 +5463,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/busboy": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dev": true,
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.16.0"
 			}
 		},
 		"node_modules/c12": {
@@ -8067,13 +7787,6 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
-		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true,
-			"license": "BSD-2-Clause"
 		},
 		"node_modules/globals": {
 			"version": "13.24.0",
@@ -12752,15 +12465,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -14102,20 +13806,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/watchpack": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.1.2"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 	"devDependencies": {
 		"@faker-js/faker": "^8.3.1",
 		"@types/csvtojson": "^2.0.0",
-		"@types/next-pwa": "^5.6.9",
 		"@types/node": "^24.13.3",
 		"@types/nodemailer": "^6.4.15",
 		"@types/qrcode": "^1.5.5",

--- a/src/types/next-pwa.d.ts
+++ b/src/types/next-pwa.d.ts
@@ -1,0 +1,11 @@
+declare module "next-pwa" {
+	import type { NextConfig } from "next";
+
+	const withPWA: (options: {
+		dest: string;
+		register?: boolean;
+		disable?: boolean;
+	}) => (config: NextConfig) => NextConfig;
+
+	export = withPWA;
+}


### PR DESCRIPTION
## Summary
- Remove the obsolete `@types/next-pwa` stub package
- Add a minimal local declaration for the JavaScript `next-pwa` config
- Remove the nested vulnerable Next.js 13 dependency

## Validation
- `npm ci --include=dev`
- `npm audit --omit=optional --audit-level=high` reports 0 vulnerabilities
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `node --import tsx --test test/email.test.ts`