### PR TITLE
fix(deploy): skip traffic split in single revision mode

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -135,10 +135,6 @@ jobs:
             --resource-group "$AZURE_RESOURCE_GROUP" \
             --name track-the-hack \
             --image "${AZURE_ACR_LOGIN_SERVER}/track-the-hack:${GITHUB_SHA}"
-          retry_az az containerapp ingress traffic set \
-            --resource-group "$AZURE_RESOURCE_GROUP" \
-            --name track-the-hack \
-            --revision-weight latest=100
           retry_az az containerapp update \
             --resource-group "$AZURE_RESOURCE_GROUP" \
             --name track-the-hack-prisma \


### PR DESCRIPTION
The production workflow successfully updates the single-revision Container App, then fails by attempting to set revision traffic, which Azure only permits in multiple-revision mode. Remove that invalid no-op so the workflow can continue to update Prisma Studio and configure health probes.